### PR TITLE
Override text decoration for unit buttons

### DIFF
--- a/src/components/units/button/_button.scss
+++ b/src/components/units/button/_button.scss
@@ -25,6 +25,10 @@
     @include defaultFocus;
   }
 
+  .sir-trevor-text & {
+    text-decoration: none;
+  }
+
   &--arrowed {
     align-items: center;
     display: inline-flex;


### PR DESCRIPTION
Issue: vanda/vam-web#2395