### PR TITLE
Remove box-shadow from focused block-grid footer anchor

### DIFF
--- a/src/components/groups/block-grid/_block-grid.scss
+++ b/src/components/groups/block-grid/_block-grid.scss
@@ -67,6 +67,8 @@
     }
 
     > a:focus {
+      box-shadow: none;
+
       .b-icon-badge__icon {
         @include defaultFocus;
       }


### PR DESCRIPTION
Issue: vanda/vam-web#2756