### PR TITLE
Replace smooth-scroll dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12685,10 +12685,6 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
-    "smooth-scroll": {
-      "version": "git+https://github.com/cferdinandi/smooth-scroll.git#35939c17b602772a1f9abc9272c3f668697be8ba",
-      "from": "git+https://github.com/cferdinandi/smooth-scroll.git#35939c17b602772a1f9abc9272c3f668697be8ba"
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "clamp-js": "^0.7.0",
     "element-closest-polyfill": "^1.0.5",
     "openseadragon": "^2.4.2",
-    "smooth-scroll": "git+https://github.com/cferdinandi/smooth-scroll.git#35939c17b602772a1f9abc9272c3f668697be8ba",
     "svg4everybody": "^2.1.9",
     "vanilla-lazyload": "^17.8.3"
   }

--- a/src/components/base/reset/_reset.scss
+++ b/src/components/base/reset/_reset.scss
@@ -24,6 +24,11 @@ section {
 
 html {
   font-size: fontSize($base-font-size) + px;
+  scroll-behavior: smooth;
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    scroll-behavior: auto;
+  }
 }
 
 body {


### PR DESCRIPTION
This dependency is due to be removed from vam-web too. In the current repository it has been included but not initialised; it does not appear to be in use.