### PR TITLE
Add label option to exhibition promotions

### DIFF
--- a/src/components/blocks/exhibition-promo/_exhibition-promo.scss
+++ b/src/components/blocks/exhibition-promo/_exhibition-promo.scss
@@ -2,6 +2,36 @@
 @use "../../base";
 
 .b-exhibition-promo {
+  .u-label-tag {
+    margin: 0 12px 12px 0;
+
+    @include mixins.breakpoints-bpMinXSmall {
+      margin-left: 10px;
+    }
+
+    @include mixins.breakpoints-bpMinSmall {
+      margin-left: 55px;
+    }
+
+    @include mixins.breakpoints-bpMinMedium {
+      margin-left: 30px;
+    }
+
+    @include mixins.breakpoints-bpMinLarge {
+      margin-left: 50px;
+    }
+  }
+
+  &--double .u-label-tag {
+    @include mixins.breakpoints-bpMinMedium {
+      margin-left: 10px;
+    }
+
+    @include mixins.breakpoints-bpMinLarge {
+      margin-left: 20px;
+    }
+  }
+
   &__title {
     @include base.typography-typeSetting(6, "bold");
 
@@ -27,7 +57,7 @@
       @include base.typography-typeSetting(5, "bold");
     }
   }
-  
+
   &__anchor {
     aspect-ratio: 0.78;
     display: block;
@@ -96,6 +126,16 @@
     }
   }
 
+  &--double &__information {
+    @include mixins.breakpoints-bpMinMedium {
+      padding: 0 20px 20px;
+    }
+
+    @include mixins.breakpoints-bpMinLarge {
+      padding: 0 178px 30px 30px;
+    }
+  }
+
   &__type {
     @include base.typography-typeSetting(3, "bold");
 
@@ -107,6 +147,18 @@
 
     @include mixins.breakpoints-bpMinSmall {
       @include base.typography-typeSetting(3, "bold");
+    }
+  }
+
+  &--double &__type {
+    @include mixins.breakpoints-bpMinMedium {
+      @include base.typography-typeSetting(2, "bold");
+
+      margin-bottom: 0;
+    }
+
+    @include mixins.breakpoints-bpMinLarge {
+      margin-bottom: 5px;
     }
   }
 
@@ -131,6 +183,12 @@
     }
   }
 
+  &--double &__description {
+    @include mixins.breakpoints-bpMinMedium {
+      @include mixins.elementvisibility-visuallyHidden;
+    }
+  }
+
   &__date {
     @include base.typography-typeSetting(2, "bold");
 
@@ -149,46 +207,6 @@
     }
   }
 
-  &__venue {
-    @include base.typography-typeSetting(2, "bold");
-
-    margin-bottom: 0;
-    order: 5;
-    text-transform: capitalize;
-
-    @include mixins.breakpoints-bpMinMedium {
-      @include base.typography-typeSetting(3);
-    }
-  }
-
-  &--double &__information {
-    @include mixins.breakpoints-bpMinMedium {
-      padding: 0 20px 20px;
-    }
-
-    @include mixins.breakpoints-bpMinLarge {
-      padding: 0 178px 30px 30px;
-    }
-  }
-
-  &--double &__type {
-    @include mixins.breakpoints-bpMinMedium {
-      @include base.typography-typeSetting(2, "bold");
-
-      margin-bottom: 0;
-    }
-
-    @include mixins.breakpoints-bpMinLarge {
-      margin-bottom: 5px;
-    }
-  }
-
-  &--double &__description {
-    @include mixins.breakpoints-bpMinMedium {
-      @include mixins.elementvisibility-visuallyHidden;
-    }
-  }
-
   &--double &__date {
     @include mixins.breakpoints-bpMinMedium {
       @include base.typography-typeSetting(2, "bold");
@@ -198,6 +216,18 @@
 
     @include mixins.breakpoints-bpMinLarge {
       margin-top: 20px;
+    }
+  }
+
+  &__venue {
+    @include base.typography-typeSetting(2, "bold");
+
+    margin-bottom: 0;
+    order: 5;
+    text-transform: capitalize;
+
+    @include mixins.breakpoints-bpMinMedium {
+      @include base.typography-typeSetting(3);
     }
   }
 

--- a/src/components/blocks/exhibition-promo/exhibition-promo.config.js
+++ b/src/components/blocks/exhibition-promo/exhibition-promo.config.js
@@ -24,6 +24,13 @@ module.exports = {
       context: {
         modifiers: ['double']
       }
+    },
+    {
+      name: 'With Tag',
+      label: 'With Tag',
+      context: {
+        eventTag: true
+      }
     }
   ]
 };

--- a/src/components/blocks/exhibition-promo/exhibition-promo.html
+++ b/src/components/blocks/exhibition-promo/exhibition-promo.html
@@ -1,5 +1,10 @@
 <article class="b-exhibition-promo{% for m in modifiers %} b-exhibition-promo--{{ m }}{% endfor %}" itemscope itemprop="exhibition" itemtype="https://schema.org/ExhibitionEvent">
   <a href="{{ url }}" class="b-exhibition-promo__anchor">
+    
+    {% if eventTag %}
+      {%- render "@label-tag--sold-out" -%}
+    {% endif %}
+    
     <img
       class="b-exhibition-promo__img"
       alt="{{ title }}"

--- a/src/components/groups/exhibition-promo-grid/_exhibition-promo-grid.scss
+++ b/src/components/groups/exhibition-promo-grid/_exhibition-promo-grid.scss
@@ -1,18 +1,20 @@
 @use "../../mixins";
 
-.b-exhibition-promo__list {
-  @include mixins.unstyledelements-unstyledList;
+.b-exhibition-promo {
+  &__list {
+    @include mixins.unstyledelements-unstyledList;
 
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-
-  @include mixins.breakpoints-bpMinMedium {
-    column-gap: 20px;
-    flex-direction: row;
-  }
-
-  @include mixins.breakpoints-bpMinLarge {
-    column-gap: 30px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  
+    @include mixins.breakpoints-bpMinMedium {
+      column-gap: 20px;
+      flex-direction: row;
+    }
+  
+    @include mixins.breakpoints-bpMinLarge {
+      column-gap: 30px;
+    }
   }
 }

--- a/src/components/groups/exhibition-promo-grid/exhibition-promo-grid.config.js
+++ b/src/components/groups/exhibition-promo-grid/exhibition-promo-grid.config.js
@@ -1,4 +1,13 @@
 module.exports = {
   title: 'Exhibition Promo double',
-  label: 'Exhibition Promo double'
+  label: 'Exhibition Promo double',
+  variants: [
+    {
+      name: 'With Tag',
+      label: 'With Tag',
+      context: {
+        eventTag: true
+      }
+    }
+  ]
 };

--- a/src/components/groups/exhibition-promo-grid/exhibition-promo-grid.html
+++ b/src/components/groups/exhibition-promo-grid/exhibition-promo-grid.html
@@ -1,7 +1,11 @@
 <ul class="b-exhibition-promo__list">
   {% for n in [1, 2] %}
-    <li>  
-      {%- render "@exhibition-promo--double" -%}
+    <li>
+      {% if eventTag %}
+        {%- render "@exhibition-promo--double", { eventTag: true }, merge=true -%}
+      {% else %}
+        {%- render "@exhibition-promo--double" -%}
+      {% endif %}
     </li>
   {% endfor %}
 </ul>

--- a/src/components/units/label-tag/_label-tag.scss
+++ b/src/components/units/label-tag/_label-tag.scss
@@ -4,12 +4,12 @@
 
 .u-label-tag {
   @include base.typography-typeSetting(2, "bold");
-
+ 
   background: base.sitecolors-siteColor("primary-green");
   bottom: initial;
   color: base.sitecolors-siteColor(vam-black);
   margin: 12px 12px 12px 0;
-  padding: 5px 12px 4px;
+  padding: 4px 10px;
   position: absolute;
   top: 0;
   z-index: 1;


### PR DESCRIPTION
[https://vandam.atlassian.net/browse/WEB-2682](https://vandam.atlassian.net/browse/WEB-2682)

In `src/components/groups/exhibition-promo-grid/exhibition-promo-grid.html` we are rendering the 'double' variation of the `exhibition-promo` block like so: `{%- render "@exhibition-promo--double" -%}`

When calling the block above, I have not found a means of including notification that the block should contain a status tag (i.e., @label-tag). I have tried using the extra argument available in various ways like so: `{%- render "@exhibition-promo--double, {eventTag: true } -%}` 

To get round this I have put a call to render the tag in `components/groups/exhibition-promo-grid--with-tag` outside of the `<article>` element rendered by `components/blocks/exhibition-promo` - please note the alternate placement in the markup at `src/components/blocks/exhibition-promo/exhibition-promo.html` vs. `src/components/groups/exhibition-promo-grid/exhibition-promo-grid.html`. 

Is there a better or cleaner way of doing this please? 


