### PR TITLE
Stc2 830 focused search category label change

### DIFF
--- a/src/components/blocks/search-form/search-form.config.js
+++ b/src/components/blocks/search-form/search-form.config.js
@@ -12,15 +12,15 @@ module.exports = {
       },
       {
         value: 'q_object_name',
-        textContent: 'Object Type/title'
+        textContent: 'Title  / object type'
       },
       {
         value: 'q_actor',
-        textContent: 'Artist/maker'
+        textContent: 'Artist / maker'
       },
       {
         value: 'q_material_technique',
-        textContent: 'Materials and Techniques'
+        textContent: 'Materials / techniques'
       },
       {
         value: 'q_place_name',

--- a/src/components/blocks/search-form/search-form.html
+++ b/src/components/blocks/search-form/search-form.html
@@ -16,7 +16,7 @@
       <label class="b-search-form__label b-search-form__advanced-search-label" for="sel_etc">Focused search</label>
       <select name="sel_etc" id="sel_etc" class="b-search-form__filter-select">
         {% for option in selectOptions %}
-          <option data-focused-category-label="{{ option.textContent }}" value="{{ option.value }}">{{ option.textContent }}</option>
+          <option data-focused-category-label="{{ option.textContent.toLowerCase() }}" value="{{ option.value }}">{{ option.textContent }}</option>
         {% endfor %}
       </select>
     </div>

--- a/src/components/blocks/search-form/search-form.html
+++ b/src/components/blocks/search-form/search-form.html
@@ -1,5 +1,5 @@
 {% if modifiers and 'etc-gateway' in modifiers %}
-  <p class="b-search-form__label" id="etc-gateway-search-input">Search more than 1.2 million objects</p>
+  <p class="b-search-form__label" id="etc-gateway-search-input">Search more than 1.25 million objects</p>
 {% endif %}
 <form class="b-search-form {% for m in modifiers %} b-search-form--{{ m }}{% endfor %} {{ jsHook }}" name="search" action="{{ action }}" method="get" role="search">
   {# Collections Landing pg #}
@@ -16,7 +16,7 @@
       <label class="b-search-form__label b-search-form__advanced-search-label" for="sel_etc">Focused search</label>
       <select name="sel_etc" id="sel_etc" class="b-search-form__filter-select">
         {% for option in selectOptions %}
-          <option value="{{ option.value }}">{{ option.textContent }}</option>
+          <option data-focused-category-label="{{ option.textContent }}" value="{{ option.value }}">{{ option.textContent }}</option>
         {% endfor %}
       </select>
     </div>


### PR DESCRIPTION
Sync updates across focused search components. 

Draft PR as data-focused-category-label values may need a string replacement to match with direct implementation. 
"/" character swapped for "or" in data attribute. ( I couldnt see a replace helper in place so may need to add one to fractal config for string replace transforms)