### PR TITLE
Keyboard event Keycode deprecation and replacement key values

### DIFF
--- a/src/components/blocks/image-carousel/_image-carousel.js
+++ b/src/components/blocks/image-carousel/_image-carousel.js
@@ -177,13 +177,13 @@ if (imageCarousel && images.length) {
   document.addEventListener('keydown', (e) => {
     if (document.querySelector('.b-image-overlay__container--active')
       && document.activeElement !== osd.canvas) {
-      if (e.key === 37) {
+      if (e.key === 'ArrowLeft') {
         const index = parseInt(imageCarousel.dataset.index, 10) - 1;
         if (index >= 0) {
           changeIndex(index);
         }
       }
-      if (e.key === 39) {
+      if (e.key === 'ArrowRight') {
         const index = parseInt(imageCarousel.dataset.index, 10) + 1;
         if (index < images.length) {
           changeIndex(index);

--- a/src/components/blocks/image-overlay-license-modal/_image-overlay-license-modal.js
+++ b/src/components/blocks/image-overlay-license-modal/_image-overlay-license-modal.js
@@ -116,7 +116,7 @@ window.addEventListener('keydown', (e) => {
 
   if (activeModal) {
     // https://stackoverflow.com/a/60031728 w/ modifications
-    if (e.key === 9) {
+    if (e.key === 'Tab') {
       const focusable = activeContent.querySelectorAll(`
         .b-image-overlay-license-modal__close-container,
         .b-image-overlay-license-modal__title-section a,
@@ -143,11 +143,11 @@ window.addEventListener('keydown', (e) => {
     }
   }
 
-  if (e.key === 13 && document.activeElement.classList.contains('b-image-overlay-license-modal__contact-modal-open')) {
+  if (e.key === 'Enter' && document.activeElement.classList.contains('b-image-overlay-license-modal__contact-modal-open')) {
     document.activeElement.click();
   }
 
-  if (activeModal && e.key === 27) {
+  if (activeModal && e.key === 'Escape') {
     modal.classList.remove('b-modal--active');
     modal.dispatchEvent(new CustomEvent('jsModalClosed', { bubbles: true }));
     e.preventDefault();

--- a/src/components/blocks/modal/_modal.js
+++ b/src/components/blocks/modal/_modal.js
@@ -25,7 +25,7 @@ Array.from(modals, (modal) => {
   };
 
   const focusHandler = (e) => {
-    if (e.key === 9) {
+    if (e.key === 'Tab') {
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
       const shift = e.shiftKey;

--- a/src/components/groups/image-overlay/_image-overlay.js
+++ b/src/components/groups/image-overlay/_image-overlay.js
@@ -69,7 +69,7 @@ const initObjectOverlay = () => {
     });
 
     window.addEventListener('keydown', (e) => {
-      if (e.key === 27) {
+      if (e.key === 'Escape') {
         if (!document.querySelector('.b-image-overlay').classList.contains('b-image-overlay--unfocus')) {
           closeObjectOverlay();
         } else {
@@ -77,9 +77,8 @@ const initObjectOverlay = () => {
         }
       }
 
-      if (
-        !document.querySelector('.b-image-overlay').classList.contains('b-image-overlay--unfocus')
-        && e.key === 9
+      if (!document.querySelector('.b-image-overlay').classList.contains('b-image-overlay--unfocus')
+        && e.key === 'Tab'
       ) {
         // stackoverflow answer 60031728
         const focusable = Array.from(document.querySelector('.b-image-overlay__content').querySelectorAll('button')).filter(


### PR DESCRIPTION
Escape wasnt working on Image overlays in ETC - event keycode term has been updated but values were still referencing the keycode numbers, not the new Strings used for key