### PR TITLE
Update event-teaser block to include dark variant class name

### DIFF
--- a/src/components/blocks/event-teaser/event-teaser.html
+++ b/src/components/blocks/event-teaser/event-teaser.html
@@ -41,7 +41,7 @@
         {{ eventTitle }}
       </h2>
 
-      <div class="b-icon-list{% for m in modifiers %} b-icon-list--{{ m }}{% endfor %}">
+      <div class="{% if modifiers and 'dark' in modifiers %}b-icon-list b-icon-list--dark{% else %}b-icon-list{% endif %}">
         <ul class="b-icon-list__list">
           <li class="b-icon-list__item b-icon-list__icon b-icon-list__icon--calendar" title="Calendar timing">
             <div class='b-icon-list__content'>
@@ -59,7 +59,7 @@
       </div>
     </div>
 
-    <div class="b-icon-list{% for m in modifiers %} b-icon-list--{{ m }}{% endfor %}">
+    <div class="{% if modifiers and 'dark' in modifiers %}b-icon-list b-icon-list--dark{% else %}b-icon-list{% endif %}">
       <ul class="b-icon-list__list b-event-teaser__footer">
         <li class="b-icon-list__item b-icon-list__icon b-icon-list__icon--ticket" title="Admission fee">
           <div class='b-icon-list__content'>

--- a/src/components/blocks/event-teaser/event-teaser.html
+++ b/src/components/blocks/event-teaser/event-teaser.html
@@ -41,7 +41,7 @@
         {{ eventTitle }}
       </h2>
 
-      <div class="b-icon-list">
+      <div class="b-icon-list{% for m in modifiers %} b-icon-list--{{ m }}{% endfor %}">
         <ul class="b-icon-list__list">
           <li class="b-icon-list__item b-icon-list__icon b-icon-list__icon--calendar" title="Calendar timing">
             <div class='b-icon-list__content'>
@@ -59,7 +59,7 @@
       </div>
     </div>
 
-    <div class="b-icon-list">
+    <div class="b-icon-list{% for m in modifiers %} b-icon-list--{{ m }}{% endfor %}">
       <ul class="b-icon-list__list b-event-teaser__footer">
         <li class="b-icon-list__item b-icon-list__icon b-icon-list__icon--ticket" title="Admission fee">
           <div class='b-icon-list__content'>

--- a/src/components/blocks/event-teaser/event-teaser.html
+++ b/src/components/blocks/event-teaser/event-teaser.html
@@ -41,7 +41,7 @@
         {{ eventTitle }}
       </h2>
 
-      <div class="{% if modifiers and 'dark' in modifiers %}b-icon-list b-icon-list--dark{% else %}b-icon-list{% endif %}">
+      <div class="b-icon-list{% if modifiers and 'dark' in modifiers %} b-icon-list--dark{% endif %}">
         <ul class="b-icon-list__list">
           <li class="b-icon-list__item b-icon-list__icon b-icon-list__icon--calendar" title="Calendar timing">
             <div class='b-icon-list__content'>
@@ -59,7 +59,7 @@
       </div>
     </div>
 
-    <div class="{% if modifiers and 'dark' in modifiers %}b-icon-list b-icon-list--dark{% else %}b-icon-list{% endif %}">
+    <div class="b-icon-list{% if modifiers and 'dark' in modifiers %} b-icon-list--dark{% endif %}">
       <ul class="b-icon-list__list b-event-teaser__footer">
         <li class="b-icon-list__item b-icon-list__icon b-icon-list__icon--ticket" title="Admission fee">
           <div class='b-icon-list__content'>


### PR DESCRIPTION
The icon-list reference within the event-teaser block was missing the correct class name for the dark variant.