### PR TITLE
Web 3469 card component updates

### DIFF
--- a/src/components/blocks/card/_card.scss
+++ b/src/components/blocks/card/_card.scss
@@ -17,6 +17,10 @@
   /* default focus style can be clipped if inside a carousel */
   @include mixins.focus-raisedPseudoFocus;
 
+  &:visited {
+    color: base.sitecolors-siteColor("vam-grey-3");
+  }
+
   &__image-container {
     overflow: hidden;
   }
@@ -183,6 +187,10 @@
     border-bottom: none;
     color: base.sitecolors-siteColor("vam-white");
 
+    &:visited {
+      color: base.sitecolors-siteColor("vam-white");
+    }
+
     &::after {
       background:
         linear-gradient(
@@ -211,14 +219,6 @@
         padding-top: 198px;
       }
     }
-  }
-
-  &:visited {
-    color: base.sitecolors-siteColor("vam-grey-3");
-  }
-
-  &--picture-card:visited {
-    color: base.sitecolors-siteColor("vam-white");
   }
 
   &:hover &__image,

--- a/src/components/blocks/card/_card.scss
+++ b/src/components/blocks/card/_card.scss
@@ -55,11 +55,13 @@
 
   &__heading {
     @include base.typography-typeSetting(4, "bold");
+    @include base.typography-lineheight(3);
 
     margin-bottom: 8px;
 
     @include mixins.breakpoints-bpMinXSmall {
       @include base.typography-typeSetting(5, "bold");
+      @include base.typography-lineheight(4);
     }
   }
 

--- a/src/components/blocks/card/_card.scss
+++ b/src/components/blocks/card/_card.scss
@@ -211,11 +211,11 @@
     }
   }
 
-  &:visited &__info-container {
+  &:visited {
     color: base.sitecolors-siteColor("vam-grey-3");
   }
 
-  &--picture-card:visited .b-card__info-container {
+  &--picture-card:visited {
     color: base.sitecolors-siteColor("vam-white");
   }
 

--- a/src/components/blocks/card/_card.scss
+++ b/src/components/blocks/card/_card.scss
@@ -71,7 +71,6 @@
 
   &__synopsis {
     @include base.typography-typeSetting(3);
-    @include base.typography-lineheight(1);
 
     -webkit-box-orient: vertical;
     display: -webkit-box;
@@ -83,7 +82,6 @@
 
     @include mixins.breakpoints-bpMinXSmall {
       @include base.typography-typeSetting(4);
-      @include base.typography-lineheight(3);
     }
   }
 
@@ -118,7 +116,6 @@
     .b-card__synopsis {
       @include mixins.breakpoints-bpMinMedium {
         @include base.typography-typeSetting(5);
-        @include base.typography-lineheight(4);
       }
     }
 


### PR DESCRIPTION
[https://vandam.atlassian.net/browse/WEB-3469](https://vandam.atlassian.net/browse/WEB-3469)

Two commits are the ticket alterations to line heights and the others are an update to the :visited pseudo-class selectors removing extraneous child selectors and reordering within the stylesheet.

Tycho:
[https://github.com/vanda/vam-web/pull/4691](https://github.com/vanda/vam-web/pull/4691)