### PR TITLE
STA-94 list card

### DIFF
--- a/src/assets/styles/preview-styles/_base.scss
+++ b/src/assets/styles/preview-styles/_base.scss
@@ -38,6 +38,10 @@ h2 {
   background-color: base.sitecolors-siteColor("vam-white");
 }
 
+.fr-content-edge-space {
+  padding: 10px 10px 20px;
+}
+
 .fr-content-wrapper,
 .fr-content-bg {
   padding: 0 calc((100vw - 1200px) / 2);

--- a/src/assets/styles/vam-style.scss
+++ b/src/assets/styles/vam-style.scss
@@ -43,6 +43,7 @@
 @use "../../components/blocks/pagination/pagination";
 @use "../../components/blocks/programme-page-tout/programme-page-tout";
 @use "../../components/blocks/promo/promo";
+@use "../../components/blocks/record-card/record-card";
 @use "../../components/blocks/review/review";
 @use "../../components/blocks/section-header/section-header";
 @use "../../components/blocks/search-form/search-form";

--- a/src/components/blocks/record-card/_record-card.scss
+++ b/src/components/blocks/record-card/_record-card.scss
@@ -1,0 +1,206 @@
+@use "../../mixins";
+@use "../../base";
+
+.b-record-card {
+  @include base.typography-typeSetting(2);
+
+  background: base.sitecolors-siteColor("vam-white");
+  border-radius: 2px;
+  color: base.sitecolors-siteColor("vam-black");
+  display: block;
+  padding: 8px;
+
+  &__info-container {
+    border-bottom: 1px solid base.sitecolors-siteColor("vam-grey-4");
+
+    > p {
+      margin-bottom: 8px;
+    }
+  }
+  
+  &__heading {
+    @include base.typography-typeSetting(3);
+
+    margin-bottom: 8px;
+  }
+
+  &__label-tag {
+    background: base.sitecolors-siteColor("vam-grey-6");
+    border-radius: 2px;
+    flex: 0 0 auto;
+    margin-bottom: 8px;
+    margin-top: 2px;
+    padding: 2px 4px;
+  }
+
+  &:hover,
+  &:focus-visible,
+  &.selected {
+    background: base.sitecolors-siteColor("vam-grey-6");
+
+    .b-record-card__info-container {
+      border-bottom-color: transparent;
+    }
+
+    .b-record-card__label-tag {
+      background-color: base.sitecolors-siteColor("vam-grey-4");
+    }
+  }
+
+  &:hover,
+  &:focus-visible {
+    .b-record-card__heading {
+      text-decoration: underline;
+    }
+  }
+
+  // :visited property on the anchor cannot override child element property where set
+  // i.e., colour property on .b-record-card__reference
+  &:visited {
+    color: base.sitecolors-siteColor("vam-grey-3");
+  }
+
+  &__image-container {
+    border-radius: 2px 2px 0 0;
+    overflow: hidden;
+    position: relative;
+  }
+
+  &__image {
+    height: 100%;
+    object-fit: cover;
+    transform: scale(1);
+    transition: 0.25s ease-out;
+    width: 100%;
+  }
+
+  &:hover &__image,
+  &:focus-visible &__image {
+    transform: scale(1.1);
+  }
+
+  &__distribution {
+    display: flex;
+    flex: 100%;
+    gap: 10px;
+
+    @include mixins.breakpoints-bpMinSmall {
+      align-items: baseline;
+      flex: 0 0 auto;
+      justify-content: flex-end
+    }
+  }
+
+  &__date {
+    @include base.typography-typeSetting(3);
+
+    align-self: flex-end;
+    flex: 50%;
+  }
+
+  &__extent,
+  &__reference {
+    flex: 50%;
+    text-align: right;
+  }
+
+  &__reference {
+    align-self: flex-end;
+    color: base.sitecolors-siteColor("vam-grey-2");
+    margin-bottom: 8px;
+    text-align: right;
+  }
+
+  &__extent {
+    @include mixins.breakpoints-bpMaxSmall {
+      @include mixins.elementvisibility-visuallyHidden;
+    }
+  }
+
+  // has a thumbnail image
+  &:has(.b-record-card__image-container) {
+    display: flex;
+    gap: 12px;
+
+    .b-record-card__image-container {
+      border-radius: 0;
+      flex: 1 1 0;
+    }
+
+    // thumbnail images are not designed to expand in height
+    .b-record-card__image {
+      height: 57px;
+    }
+
+    .b-record-card__info-container {
+      flex: 2 2 0;
+      padding: 0;
+    }
+  }
+
+  // is an Archive Series card
+  &:has(.b-record-card__distribution) {
+    .b-record-card__info-container {
+      display: flex;
+      flex-wrap: wrap;
+      padding: 0;
+    }
+
+    .b-record-card__heading {
+      @include base.typography-typeSetting(4);
+      @include base.typography-lineheight(3);
+
+      flex: 100%;
+
+      @include mixins.breakpoints-bpMinSmall {
+        flex: 50%;
+      }
+    }
+  }
+
+  &.selected {
+    .b-record-card__heading {
+      font-variation-settings: "wght" 500;
+      text-decoration: none;
+    }
+  }
+  
+  // is an Archive Series card AND has a thumbnail image
+  &:has(.b-record-card__distribution):has(.b-record-card__image-container) {
+    display: flex;
+    gap: 12px;
+
+    .b-record-card__image-container {
+      border-radius: 0;
+      flex: 1 1 0;
+    }
+
+    // thumbnail images are not designed to expand in height
+    .b-record-card__image {
+      height: 78px;
+
+      // for use when an optional u-label element is associated.
+      &--large {
+        height: 94px;
+      }
+
+      @include mixins.breakpoints-bpMinSmall {
+        height: 94px;
+      }
+    }
+
+    .b-record-card__info-container {
+      flex: 2 2 0;
+
+      @include mixins.breakpoints-bpMinSmall {
+        flex: 4 4 0;
+      }
+    }
+
+    .b-record-card__heading {
+      @include mixins.breakpoints-bpMinSmall {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/src/components/blocks/record-card/record-card.config.js
+++ b/src/components/blocks/record-card/record-card.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  title: 'Record Card',
+  context: {
+    previewClass: 'fr-bg--dark fr-content-edge-space',
+    image: {
+      320: 'https://picsum.photos/id/25/320/240',
+      640: 'https://picsum.photos/id/25/640/480',
+    },
+    heading: 'Vivien Leigh Archive',
+    date: '1925-1967',
+    reference: 'THM/433',
+    extent: '90 Boxes',
+  }
+};

--- a/src/components/blocks/record-card/record-card.html
+++ b/src/components/blocks/record-card/record-card.html
@@ -1,0 +1,106 @@
+
+<!-- Default Record Card -->
+
+<a href="#" class="b-record-card">
+  <div class="b-record-card__info-container">
+    <h2 class="b-record-card__heading">Material relating to Vivien Leigh's Career</h2>
+  </div>
+</a>
+
+<br><br>
+<!-- Default Record Card with thumbnail image -->
+
+<a href="#" class="b-record-card">
+  <div class="b-record-card__image-container">
+    <img alt="" 
+      class="b-record-card__image" 
+      srcset="{{ image[320] }} 320w,
+              {{ image[640] }} 640w" 
+      sizes="100vw" 
+      src="{{ image[320] }}" 
+      loading="lazy">
+  </div>
+  <div class="b-record-card__info-container">
+    <h2 class="b-record-card__heading">Theatre and Performance</h2>
+  </div>
+</a>
+
+<br><br>
+<!--  Archive Series Record Card -->
+
+<a href="#" class="b-record-card">
+  <div class="b-record-card__info-container">
+    <h2 class="b-record-card__heading">Vivien Leigh Archive</h2>
+    <div class="b-record-card__distribution">
+      <p class="b-record-card__extent">90 Boxes</p>
+    </div>
+    <p class="b-record-card__date">1925-1967</p>
+    <p class="b-record-card__reference">THM/433</p>
+  </div>
+</a>
+
+<br><br>
+<!--  Archive Series Record Card with label -->
+
+<a href="#" class="b-record-card">
+  <div class="b-record-card__info-container">
+    <h2 class="b-record-card__heading">Vivien Leigh Archive</h2>
+    <div class="b-record-card__distribution">
+      <div class="b-record-card__label-tag">
+        Archive Collection
+      </div>
+      <p class="b-record-card__extent">90 Boxes</p>
+    </div>
+    <p class="b-record-card__date">1925-1967</p>
+    <p class="b-record-card__reference">THM/433</p>
+  </div>
+</a>
+
+<br><br>
+<!--  Archive Series Record Card with thumbnail image -->
+
+<a href="#" class="b-record-card">
+  <div class="b-record-card__image-container">
+    <img alt="" 
+    class="b-record-card__image" 
+    srcset="{{ image[320] }} 320w,
+            {{ image[640] }} 640w" 
+    sizes="100vw" 
+    src="{{ image[320] }}" 
+    loading="lazy">
+  </div>
+  <div class="b-record-card__info-container">
+    <h2 class="b-record-card__heading">Vivien Leigh Archive</h2>
+    <div class="b-record-card__distribution">
+      <p class="b-record-card__extent">90 Boxes</p>
+    </div>
+    <p class="b-record-card__date">1925-1967</p>
+    <p class="b-record-card__reference">THM/433</p>
+  </div>
+</a>
+
+<br><br>
+<!--  Archive Series Record Card with label and thumbnail image -->
+
+<a href="#" class="b-record-card">
+  <div class="b-record-card__image-container">
+    <img alt="" 
+    class="b-record-card__image b-record-card__image--large" 
+    srcset="{{ image[320] }} 320w,
+            {{ image[640] }} 640w" 
+    sizes="100vw" 
+    src="{{ image[320] }}" 
+    loading="lazy">
+  </div>    
+  <div class="b-record-card__info-container">
+    <h2 class="b-record-card__heading">Vivien Leigh Archive</h2>
+    <div class="b-record-card__distribution">
+      <div class="b-record-card__label-tag">
+        Archive Collection
+      </div>
+      <p class="b-record-card__extent">90 Boxes</p>
+    </div>
+    <p class="b-record-card__date">1925-1967</p>
+    <p class="b-record-card__reference">THM/433</p>
+  </div>
+</a>


### PR DESCRIPTION
New EtA Record Card component.

[https://vandam.atlassian.net/browse/STA-94](https://vandam.atlassian.net/browse/STA-94)

NB. Commit [https://github.com/vanda/vam-fractal/pull/615/commits/f27440ffed25e7ea426783805601f87b6493dd4d](https://github.com/vanda/vam-fractal/pull/615/commits/f27440ffed25e7ea426783805601f87b6493dd4d) is additional and contains the modifications requested by and discussed with Dom regarding adding spacing around components so that they can be better QA tested in Surge. I have enabled this on a per component basis so that `previewClass: 'fr-content-edge-space'` can be set in the component's configuration file.